### PR TITLE
JSON parsing error on empty data object

### DIFF
--- a/addons/discord_gd/discord.gd
+++ b/addons/discord_gd/discord.gd
@@ -1079,11 +1079,10 @@ func _update_presence(new_presence: Dictionary) -> void:
 # Helper functions
 func _jsonstring_to_dict(data: String) -> Dictionary:
 	var temp = null
-	if (!data.empty()):
-		var json_parsed = JSON.parse(data)
-		return json_parsed.result
-	else:
+	if (data.empty()):
 		return temp
+	var json_parsed = JSON.parse(data)
+	return json_parsed.result
 
 
 func _setup_heartbeat_timer(interval: int) -> void:

--- a/addons/discord_gd/discord.gd
+++ b/addons/discord_gd/discord.gd
@@ -1078,8 +1078,12 @@ func _update_presence(new_presence: Dictionary) -> void:
 
 # Helper functions
 func _jsonstring_to_dict(data: String) -> Dictionary:
-	var json_parsed = JSON.parse(data)
-	return json_parsed.result
+	var temp = null
+	if (!data.empty()):
+		var json_parsed = JSON.parse(data)
+		return json_parsed.result
+	else:
+		return temp
 
 
 func _setup_heartbeat_timer(interval: int) -> void:


### PR DESCRIPTION
E 0:00:15.461   parse: Error parsing JSON at line 0: 
  <C++ Source>  core/bind/core_bind.cpp:3216 @ parse()
  <Stack Trace> discord.gd:1081 @ _jsonstring_to_dict()
                discord.gd:774 @ _send_raw_request()

When running my app I get this error. It doesn't break anything really, just don't like errors printing for no reason, so I had a look. I started by adding a string print to the method to see what was happening that could cause a line 0 JSON error:

# Helper functions
func _jsonstring_to_dict(data: String) -> Dictionary:
	print(data.substr(0, 100))
	var json_parsed = JSON.parse(data)
	return json_parsed.result

The above print statement gave me the following when the error prints:

"
{"t":"MESSAGE_UPDATE","s":6,"op":0,"d":{"type":0,"tts":false,"timestamp":"2022-02-15T21:01:39.673000

{"t":"MESSAGE_CREATE","s":7,"op":0,"d":{"type":0,"tts":false,"timestamp":"2022-02-15T21:01:50.913000
{"t":"MESSAGE_CREATE","s":8,"op":0,"d":{"type":0,"tts":false,"timestamp":"2022-02-15T21:01:51.296000
{"id": "943250782483017790", "type": 0, "content": "", "channel_id": "942345569098137614", "author":
"
That empty line is where the error takes place. This lead me to believe that the "data" object in the above method is empty. To fix this I added in a check to see if it's empty and to return a null object if so.

# Helper functions
func _jsonstring_to_dict(data: String) -> Dictionary:
	var temp = null
	if (data.empty()):
		return temp
	var json_parsed = JSON.parse(data)
	return json_parsed.result